### PR TITLE
Fixing doc example

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Sentry Interfaces could be also provided as %params, e.g.
     $sentry->warn ( 'msg', user =>  {
         "id" => "unique_id",
         "username" => "my_user",
-        "email" => "foo@example.com",
+        "email" => 'foo@example.com',
         "ip_address" => "127.0.0.1",
         "subscription" => "basic"
     });

--- a/lib/WWW/Sentry.pm
+++ b/lib/WWW/Sentry.pm
@@ -62,7 +62,7 @@ Sentry Interfaces could be also provided as %params, e.g.
     $sentry->warn ( 'msg', user =>  {
         "id" => "unique_id",
         "username" => "my_user",
-        "email" => "foo@example.com",
+        "email" => 'foo@example.com',
         "ip_address" => "127.0.0.1",
         "subscription" => "basic"
     });


### PR DESCRIPTION

        Possible unintended interpolation of @example in string at